### PR TITLE
Fix menu visibility when store is closed

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,13 +1,17 @@
 const carrito = [];
 
 document.addEventListener('DOMContentLoaded', () => {
-  fetch('assets/data/menu.json')
-    .then(response => response.json())
+  fetchStoreStatus()
+    .then(status => {
+      window.storeOpen = status;
+      applyStoreStatus(status);
+      return fetch('assets/data/menu.json').then(r => r.json());
+    })
     .then(data => {
       renderItems(data.burgers, document.querySelector('#burgers .menu-items'));
       renderItems(data.hotdogs, document.querySelector('#hotdogs .menu-items'));
     })
-    .catch(err => console.error('Error al cargar el menú', err));
+    .catch(err => console.error('Error al cargar los datos', err));
 
   document.getElementById('vaciar-carrito').addEventListener('click', () => {
     carrito.length = 0;


### PR DESCRIPTION
## Summary
- load store status before menu items
- ensure 'Agregar a Orden' only appears when store is open

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c8d80ba30832db448a80be9e9ce6c